### PR TITLE
fix: isochrone error

### DIFF
--- a/starling_sim/basemodel/algorithms/dispatcher.py
+++ b/starling_sim/basemodel/algorithms/dispatcher.py
@@ -40,7 +40,9 @@ class Dispatcher(ABC):
         self.operator = operator
 
         #: operation parameters
-        self.operationParameters = self.operator.operationParameters
+        self.operationParameters = None
+        if operator is not None:
+            self.operationParameters = self.operator.operationParameters
 
         #: verbose option
         self.verb = verb


### PR DESCRIPTION
isochrone function was not adapted for new Router class