### PR TITLE
fix: missing date parameter crash

### DIFF
--- a/starling_sim/basemodel/parameters/simulation_parameters.py
+++ b/starling_sim/basemodel/parameters/simulation_parameters.py
@@ -36,7 +36,8 @@ class SimulationParameters:
         validate_against_schema(parameters, self.schema)
 
         # change date format from YYYY-MM-DD to YYYYMMDD
-        parameters["date"] = parameters["date"].replace("-", "")
+        if "date" in parameters:
+            parameters["date"] = parameters["date"].replace("-", "")
 
         self._parametersDict = parameters
 

--- a/tests/test_data/models/FF_VS/example_nantes/inputs/Params.json
+++ b/tests/test_data/models/FF_VS/example_nantes/inputs/Params.json
@@ -3,7 +3,6 @@
     "scenario": "example_nantes",
     "limit": 35000,
     "seed": 42,
-    "date": "2019-09-19",
     "traces_output": true,
     "visualisation_output": true,
     "kpi_output": true,

--- a/tests/test_data/models/SB_VS/example_nantes/inputs/Params.json
+++ b/tests/test_data/models/SB_VS/example_nantes/inputs/Params.json
@@ -3,7 +3,6 @@
     "scenario": "example_nantes",
     "limit": 35000,
     "seed": 42,
-    "date": "2019-09-19",
     "traces_output": true,
     "visualisation_output": true,
     "kpi_output": true,

--- a/tests/test_data/models/SB_VS_R/example_nantes/inputs/Params.json
+++ b/tests/test_data/models/SB_VS_R/example_nantes/inputs/Params.json
@@ -3,7 +3,6 @@
     "scenario": "example_nantes",
     "limit": 35000,
     "seed": 42,
-    "date": "2019-09-19",
     "traces_output": true,
     "visualisation_output": true,
     "kpi_output": true,


### PR DESCRIPTION
fixed a crash happening when the date parameter was not provided
the crash was happening even when the date parameter was not required