### PR TITLE
fix: agent generation and stop event

### DIFF
--- a/starling_sim/basemodel/input/dynamic_input.py
+++ b/starling_sim/basemodel/input/dynamic_input.py
@@ -253,14 +253,18 @@ class DynamicInput(Traced):
         :param populations: population(s) where the agent belongs
         """
 
-        # add agent to relevant population
-        self.sim.agentPopulation.new_agent_in(agent, populations)
+        # cancel add to simulation if agent already exists
+        try:
+            # add agent to relevant population
+            self.sim.agentPopulation.new_agent_in(agent, populations)
 
-        # trace and log input event
-        self.trace_event(InputEvent(self.sim.scheduler.now(), agent))
+            # trace and log input event
+            self.trace_event(InputEvent(self.sim.scheduler.now(), agent))
 
-        # add the agent loop to the event manager
-        agent.main_process = self.sim.scheduler.new_process(agent.simpy_loop_())
+            # add the agent loop to the event manager
+            agent.main_process = self.sim.scheduler.new_process(agent.simpy_loop_())
+        except KeyError:
+            pass
 
     # get and manage input dicts from the input files
 

--- a/starling_sim/basemodel/population/dict_population.py
+++ b/starling_sim/basemodel/population/dict_population.py
@@ -59,10 +59,14 @@ class DictPopulation(AgentPopulation):
             population_names = [population_names]
 
         for population_name in population_names:
+            # raise KeyError exception if agent already exists (and then cancel agent add)
             if agent.id in self.population[population_name]:
-                logging.warning(
-                    "Replacing existing agent {} in population {}".format(agent.id, population_name)
+                logging.error(
+                    "Agent {} already exists in population {}, cancelled introduction of duplicate".format(
+                        agent.id, population_name
+                    )
                 )
+                raise KeyError
 
             self.population[population_name][agent.id] = agent
 

--- a/starling_sim/basemodel/trace/events.py
+++ b/starling_sim/basemodel/trace/events.py
@@ -224,7 +224,9 @@ class StopEvent(Event):
 
     def set_dropoffs(self, dropoffs, dropoff_time):
 
-        if not isinstance(dropoffs, list):
+        if dropoffs is None:
+            dropoffs = []
+        elif not isinstance(dropoffs, list):
             dropoffs = [dropoffs]
 
         self.dropoffs = dropoffs
@@ -232,7 +234,9 @@ class StopEvent(Event):
 
     def set_pickups(self, pickups, pickup_time):
 
-        if not isinstance(pickups, list):
+        if pickups is None:
+            pickups = []
+        elif not isinstance(pickups, list):
             pickups = [pickups]
 
         self.pickups = pickups


### PR DESCRIPTION
duplicate agent ids are now cancelled from being added to the simulation
fixed StopEvent management when there are no pickups/dropoffs