### PR TITLE
feat: improve run summary

### DIFF
--- a/docs/run/io.rst
+++ b/docs/run/io.rst
@@ -122,6 +122,13 @@ The main outputs of the simulation are the visualisation file and the KPI tables
 The specification of what they exactly contain is made by the model developer in the class
 extending :class:`~starling_sim.basemodel.output.output_factory.OutputFactory`.
 
+Run summary
+-----------
+
+The run summary file is a .json file generated at the end of a successful simulation.
+It contains information about the run (date, Starling version, commit), the simulation
+parameters, and the outputs of the run.
+
 Visualisation file
 ------------------
 

--- a/starling_sim/basemodel/output/geojson_output.py
+++ b/starling_sim/basemodel/output/geojson_output.py
@@ -194,7 +194,9 @@ class GeojsonOutput(ABC):
             compression = "gzip"
 
         # signal new file to output factory
-        self.sim.outputFactory.new_output_file(path, "application/json", "visualisation", compression=compression)
+        self.sim.outputFactory.new_output_file(
+            path, "application/json", "visualisation", compression=compression
+        )
 
 
 # Classes for the generation of geojson output

--- a/starling_sim/basemodel/output/geojson_output.py
+++ b/starling_sim/basemodel/output/geojson_output.py
@@ -189,7 +189,7 @@ class GeojsonOutput(ABC):
 
         # compress to bz2 if necessary
         if to_gz:
-            gz_compression(path)
+            path = gz_compression(path)
 
         # signal new file to output factory
         self.sim.outputFactory.new_output_file(path, metadata={"type": "visualisation"})

--- a/starling_sim/basemodel/output/geojson_output.py
+++ b/starling_sim/basemodel/output/geojson_output.py
@@ -188,11 +188,13 @@ class GeojsonOutput(ABC):
         json_dump(feature_collection, path)
 
         # compress to bz2 if necessary
+        compression = None
         if to_gz:
             path = gz_compression(path)
+            compression = "gzip"
 
         # signal new file to output factory
-        self.sim.outputFactory.new_output_file(path, metadata={"type": "visualisation"})
+        self.sim.outputFactory.new_output_file(path, "application/json", "visualisation", compression=compression)
 
 
 # Classes for the generation of geojson output

--- a/starling_sim/basemodel/output/geojson_output.py
+++ b/starling_sim/basemodel/output/geojson_output.py
@@ -177,9 +177,6 @@ class GeojsonOutput(ABC):
         # build file path
         path = self.folder + self.filename
 
-        # log geojson generation
-        logging.info("Generating geojson output in file " + path)
-
         # check bz2 extension
         if path.endswith(".gz"):
             to_gz = True
@@ -193,6 +190,9 @@ class GeojsonOutput(ABC):
         # compress to bz2 if necessary
         if to_gz:
             gz_compression(path)
+
+        # signal new file to output factory
+        self.sim.outputFactory.new_output_file(path, metadata={"type": "visualisation"})
 
 
 # Classes for the generation of geojson output

--- a/starling_sim/basemodel/output/geojson_output.py
+++ b/starling_sim/basemodel/output/geojson_output.py
@@ -188,14 +188,14 @@ class GeojsonOutput(ABC):
         json_dump(feature_collection, path)
 
         # compress to bz2 if necessary
-        compression = None
+        mimetype = "application/json"
         if to_gz:
             path = gz_compression(path)
-            compression = "gzip"
+            mimetype = "application/gzip"
 
         # signal new file to output factory
         self.sim.outputFactory.new_output_file(
-            path, "application/json", "visualisation", compression=compression
+            path, mimetype, compressed_mimetype="application/json", content="visualisation"
         )
 
 

--- a/starling_sim/basemodel/output/kpi_output.py
+++ b/starling_sim/basemodel/output/kpi_output.py
@@ -7,6 +7,9 @@ import pandas as pd
 class KpiOutput:
     def __init__(self, population_names, kpi_list, kpi_name=None):
 
+        # simulation model access
+        self.sim = None
+
         # name of the kpi, will compose the kpi filename : <kpi_name>.csv
         if kpi_name is None:
             if isinstance(population_names, list):
@@ -39,6 +42,7 @@ class KpiOutput:
         :return:
         """
 
+        self.sim = simulation_model
         self.filename = filename
         self.folder = folder
 
@@ -109,13 +113,13 @@ class KpiOutput:
         if kpi_table.empty:
             return
 
-        # generate kpi output
-
-        logging.info("Generating KPI output in file " + path)
-
         try:
             # write the dataframe into a csv file
             kpi_table.to_csv(path, sep=";", index=False, columns=header_list)
+
+            # signal new file to output factory
+            self.sim.outputFactory.new_output_file(path, metadata={"type": "kpi", "kpi": self.name})
+
         except KeyError as e:
             logging.warning(
                 "Could not generate kpi output {}, " "error occurred : {}".format(path, e)

--- a/starling_sim/basemodel/output/kpi_output.py
+++ b/starling_sim/basemodel/output/kpi_output.py
@@ -118,7 +118,10 @@ class KpiOutput:
             kpi_table.to_csv(path, sep=";", index=False, columns=header_list)
 
             # signal new file to output factory
-            self.sim.outputFactory.new_output_file(path, metadata={"type": "kpi", "kpi": self.name})
+            compression = None
+            if path.endswith("gz"):
+                compression = "gzip"
+            self.sim.outputFactory.new_output_file(path, "text/csv", "kpi", subject=self.name, compression=compression)
 
         except KeyError as e:
             logging.warning(

--- a/starling_sim/basemodel/output/kpi_output.py
+++ b/starling_sim/basemodel/output/kpi_output.py
@@ -121,7 +121,9 @@ class KpiOutput:
             compression = None
             if path.endswith("gz"):
                 compression = "gzip"
-            self.sim.outputFactory.new_output_file(path, "text/csv", "kpi", subject=self.name, compression=compression)
+            self.sim.outputFactory.new_output_file(
+                path, "text/csv", "kpi", subject=self.name, compression=compression
+            )
 
         except KeyError as e:
             logging.warning(

--- a/starling_sim/basemodel/output/kpi_output.py
+++ b/starling_sim/basemodel/output/kpi_output.py
@@ -118,11 +118,15 @@ class KpiOutput:
             kpi_table.to_csv(path, sep=";", index=False, columns=header_list)
 
             # signal new file to output factory
-            compression = None
+            mimetype = "text/csv"
             if path.endswith("gz"):
-                compression = "gzip"
+                mimetype = "application/gzip"
             self.sim.outputFactory.new_output_file(
-                path, "text/csv", "kpi", subject=self.name, compression=compression
+                path,
+                mimetype,
+                compressed_mimetype="text/csv",
+                content="kpi",
+                subject=self.name,
             )
 
         except KeyError as e:

--- a/starling_sim/basemodel/output/output_factory.py
+++ b/starling_sim/basemodel/output/output_factory.py
@@ -111,10 +111,7 @@ class OutputFactory:
 
         logging.info("Generated {} output in file {}".format(metadata["type"], filepath))
 
-        self.output_files.append({
-            "filename": os.path.basename(filepath),
-            "metadata": metadata
-        })
+        self.output_files.append({"filename": os.path.basename(filepath), "metadata": metadata})
 
     def extract_simulation(self, simulation_model):
         """
@@ -214,11 +211,7 @@ class OutputFactory:
 
         :param simulation_model:
         """
-        filepath = (
-            simulation_model.parameters["output_folder"]
-            + "/"
-            + self.RUN_SUMMARY_FILENAME
-        )
+        filepath = simulation_model.parameters["output_folder"] + "/" + self.RUN_SUMMARY_FILENAME
 
         # add run summary to output files
         self.new_output_file(filepath, metadata={"type": "run_summary"})

--- a/starling_sim/basemodel/output/output_factory.py
+++ b/starling_sim/basemodel/output/output_factory.py
@@ -109,11 +109,7 @@ class OutputFactory:
         :return:
         """
 
-        metadata = {
-            "mimetype": mimetype,
-            "compression": compression,
-            "content": content
-        }
+        metadata = {"mimetype": mimetype, "compression": compression, "content": content}
 
         if subject is not None:
             metadata["subject"] = subject

--- a/starling_sim/basemodel/output/output_factory.py
+++ b/starling_sim/basemodel/output/output_factory.py
@@ -14,6 +14,8 @@ class OutputFactory:
     e.g. writing a json containing all the simulation data
     """
 
+    RUN_SUMMARY_FILENAME = "run_summary.json"
+
     def __init__(self):
         """
         The constructor must be extended for the needs of the generation method
@@ -209,8 +211,7 @@ class OutputFactory:
         filepath = (
             simulation_model.parameters["output_folder"]
             + "/"
-            + simulation_model.parameters["scenario"]
-            + "_summary.json"
+            + self.RUN_SUMMARY_FILENAME
         )
 
         # add run summary to output files

--- a/starling_sim/basemodel/output/output_factory.py
+++ b/starling_sim/basemodel/output/output_factory.py
@@ -16,6 +16,8 @@ class OutputFactory:
 
     RUN_SUMMARY_FILENAME = "run_summary.json"
 
+    GENERATION_ERROR_FORMAT = "Error while generating {} output"
+
     def __init__(self):
         """
         The constructor must be extended for the needs of the generation method
@@ -121,19 +123,24 @@ class OutputFactory:
         It must be extended to generate the output using specific methods.
         """
 
-        if (
-            "traces_output" in simulation_model.parameters
-            and simulation_model.parameters["traces_output"]
-        ):
-            self.generate_trace_output(simulation_model)
+        # traces output
+        if simulation_model.parameters["traces_output"]:
+            try:
+                self.generate_trace_output(simulation_model)
+            except:
+                logging.warning(self.GENERATION_ERROR_FORMAT.format("traces"))
 
         # kpi output
         if simulation_model.parameters["kpi_output"]:
             self.generate_kpi_output(simulation_model)
 
         # geojson output
+
         if simulation_model.parameters["visualisation_output"]:
-            self.generate_geojson_output(simulation_model)
+            try:
+                self.generate_geojson_output(simulation_model)
+            except:
+                logging.warning(self.GENERATION_ERROR_FORMAT.format("visualisation"))
 
         # run summary output
         self.generate_run_summary(simulation_model)
@@ -157,8 +164,10 @@ class OutputFactory:
         """
 
         for kpi_output in self.kpi_outputs:
-
-            kpi_output.write_kpi_table()
+            try:
+                kpi_output.write_kpi_table()
+            except:
+                logging.warning(self.GENERATION_ERROR_FORMAT.format(kpi_output.name + " kpi"))
 
     def generate_trace_output(self, simulation_model):
         """

--- a/starling_sim/basemodel/output/output_factory.py
+++ b/starling_sim/basemodel/output/output_factory.py
@@ -135,11 +135,8 @@ class OutputFactory:
         if simulation_model.parameters["visualisation_output"]:
             self.generate_geojson_output(simulation_model)
 
-        if (
-            "generate_summary" in simulation_model.parameters
-            and simulation_model.parameters["generate_summary"]
-        ):
-            self.generate_run_summary(simulation_model)
+        # run summary output
+        self.generate_run_summary(simulation_model)
 
     def generate_geojson_output(self, simulation_model):
         """

--- a/starling_sim/basemodel/output/output_factory.py
+++ b/starling_sim/basemodel/output/output_factory.py
@@ -95,20 +95,30 @@ class OutputFactory:
 
         self.geojson_output = new_geojson_output()
 
-    def new_output_file(self, filepath, metadata):
+    def new_output_file(self, filepath, mimetype, content, subject=None, compression=None):
         """
         Add a new file and its information to the output dict.
 
         This method should be called after generating an output file.
 
         :param filepath: output file path
-        :param metadata: output file metadata
+        :param mimetype: file mimetype
+        :param content: file content
+        :param subject: file subject (optional)
+        :param compression: file compression (leave at None if not compressed)
+        :return:
         """
 
-        if "type" not in metadata:
-            metadata["type"] = "unknown"
+        metadata = {
+            "mimetype": mimetype,
+            "compression": compression,
+            "content": content
+        }
 
-        logging.info("Generated {} output in file {}".format(metadata["type"], filepath))
+        if subject is not None:
+            metadata["subject"] = subject
+
+        logging.info("Generated {} output in file {}".format(metadata["content"], filepath))
 
         self.output_files.append({"filename": os.path.basename(filepath), "metadata": metadata})
 
@@ -202,7 +212,7 @@ class OutputFactory:
                     outfile.write("\n")
                     outfile.write(str(event))
 
-        self.new_output_file(filepath, metadata={"type": "traces"})
+        self.sim.outputFactory.new_output_file(filepath, "text/plain", "traces")
 
     def generate_run_summary(self, simulation_model):
         """
@@ -213,7 +223,7 @@ class OutputFactory:
         filepath = simulation_model.parameters["output_folder"] + RUN_SUMMARY_FILENAME
 
         # add run summary to output files
-        self.new_output_file(filepath, metadata={"type": "run_summary"})
+        self.sim.outputFactory.new_output_file(filepath, "application/json", "run_summary")
 
         # set output files in run summary and dump it in a file
         simulation_model.runSummary["output_files"] = self.output_files

--- a/starling_sim/basemodel/output/output_factory.py
+++ b/starling_sim/basemodel/output/output_factory.py
@@ -1,6 +1,7 @@
 from starling_sim.basemodel.output.geojson_output import new_geojson_output
 from starling_sim.utils.utils import json_pretty_dump
 from starling_sim.utils.config import config
+from starling_sim.utils.constants import RUN_SUMMARY_FILENAME
 
 import logging
 import os
@@ -13,8 +14,6 @@ class OutputFactory:
     This class should be extended to give a concrete implementation of the output generator
     e.g. writing a json containing all the simulation data
     """
-
-    RUN_SUMMARY_FILENAME = "run_summary.json"
 
     GENERATION_ERROR_FORMAT = "Error while generating {} output"
 
@@ -211,7 +210,7 @@ class OutputFactory:
 
         :param simulation_model:
         """
-        filepath = simulation_model.parameters["output_folder"] + "/" + self.RUN_SUMMARY_FILENAME
+        filepath = simulation_model.parameters["output_folder"] + RUN_SUMMARY_FILENAME
 
         # add run summary to output files
         self.new_output_file(filepath, metadata={"type": "run_summary"})

--- a/starling_sim/basemodel/simulation_model.py
+++ b/starling_sim/basemodel/simulation_model.py
@@ -3,9 +3,10 @@ import logging
 import numpy
 
 from starling_sim.basemodel.trace.trace import trace_simulation_end
-from starling_sim.utils.utils import import_gtfs_feed
+from starling_sim.utils.utils import import_gtfs_feed, get_git_revision_hash
 from starling_sim.utils.constants import BASE_LEAVING_CODES
 from starling_sim.utils.config import config
+from starling_sim.version import __version__
 
 
 class SimulationModel:
@@ -42,7 +43,7 @@ class SimulationModel:
         self.parameters = parameters
 
         # run_summary
-        self.runSummary = parameters.copy_dict()
+        self.runSummary = self.init_run_summary()
 
         # add the base leaving codes
         self.add_base_leaving_codes()
@@ -155,6 +156,33 @@ class SimulationModel:
         # import the gtfs timetable from the zip given in the parameters
         restrict_transfers = config["transfer_restriction"]
         self.gtfs = import_gtfs_feed(self.parameters["gtfs_timetables"], restrict_transfers)
+
+    def init_run_summary(self):
+        """
+        Initialise the run summary.
+        """
+
+        summary = dict()
+
+        # get starling version
+        summary["starling_version"] = __version__
+
+        # get current commit
+        summary["commit"] = get_git_revision_hash()
+
+        # copy scenario parameters
+        summary["parameters"] = self.parameters.copy_dict()
+
+        # copy config
+        summary["config"] = config.copy()
+
+        # scenario output files
+        summary["output_files"] = dict()
+
+        # run statistics
+        summary["stats"] = dict()
+
+        return summary
 
     @classmethod
     def get_agent_type_schemas(cls):

--- a/starling_sim/basemodel/simulation_model.py
+++ b/starling_sim/basemodel/simulation_model.py
@@ -1,6 +1,7 @@
 import random
 import logging
 import numpy
+import datetime
 
 from starling_sim.basemodel.trace.trace import trace_simulation_end
 from starling_sim.utils.utils import import_gtfs_feed, get_git_revision_hash
@@ -163,6 +164,9 @@ class SimulationModel:
         """
 
         summary = dict()
+
+        # get run date
+        summary["date"] = str(datetime.datetime.today())
 
         # get starling version
         summary["starling_version"] = __version__

--- a/starling_sim/model_simulator.py
+++ b/starling_sim/model_simulator.py
@@ -148,7 +148,7 @@ def launch_simulation(parameters_path, pkg):
     simulator.setup_simulation()
     duration = time.time() - start
     logging.info("End of setup. Elapsed time : {:.2f} seconds\n".format(duration))
-    simulator.simulationModel.runSummary["setup_time"] = duration
+    simulator.simulationModel.runSummary["stats"]["setup_time"] = duration
 
     # run the simulation
     logging.info("Starting the simulation\n")
@@ -156,13 +156,13 @@ def launch_simulation(parameters_path, pkg):
     simulator.run_simulation()
     duration = time.time() - start
     logging.info("End of simulation run. Elapsed time : {:.2f} seconds\n".format(duration))
-    simulator.simulationModel.runSummary["execution_time"] = duration
+    simulator.simulationModel.runSummary["stats"]["execution_time"] = duration
 
     shortest_path_count = 0
     for topology in simulator.simulationModel.environment.topologies.values():
         shortest_path_count += topology.shortest_path_count
     logging.info("Number of shortest_path computed : {}".format(shortest_path_count))
-    simulator.simulationModel.runSummary["shortest_paths"] = shortest_path_count
+    simulator.simulationModel.runSummary["stats"]["shortest_paths"] = shortest_path_count
 
     # generate simulation output
     logging.info("Generating outputs of the simulation\n")

--- a/starling_sim/schemas/parameters.schema.json
+++ b/starling_sim/schemas/parameters.schema.json
@@ -88,13 +88,6 @@
       "description": "Log simulation time every 3600 seconds (used for run monitoring)",
       "default": false
     },
-    "generate_summary": {
-      "advanced": true,
-      "title": "Generate run summary",
-      "description": "Generate a simulation run summary",
-      "type": "boolean",
-      "default": false
-    },
     "early_dynamic_input": {
       "advanced":  true,
       "type": "integer",

--- a/starling_sim/utils/constants.py
+++ b/starling_sim/utils/constants.py
@@ -37,6 +37,9 @@ BASE_LEAVING_CODES = {
 
 # filename formats
 
+#: filename of the run summary file
+RUN_SUMMARY_FILENAME = "run_summary.json"
+
 #: format of the ALIENS operators usage diagram
 OPERATORS_USAGE_FORMAT = "{prefix}_operators.png"
 

--- a/starling_sim/utils/paths.py
+++ b/starling_sim/utils/paths.py
@@ -66,8 +66,6 @@ Structure of the data folder
         |   └── scenario_2      # scenario_2 data
         └── ...
 
-The path to the data repository and the names of the folders can be changed.
-
 The path to the data repository can be changed using the --data-folder option of main.py
 
 .. code-block:: bash

--- a/starling_sim/utils/utils.py
+++ b/starling_sim/utils/utils.py
@@ -115,13 +115,16 @@ def gz_compression(filepath, delete_source=True):
     """
 
     # compress the file using gzip
+    compressed_path = filepath + ".gz"
     with open(filepath, "rb") as f_in:
-        with gzip.open(filepath + ".gz", "wb") as f_out:
+        with gzip.open(compressed_path, "wb") as f_out:
             shutil.copyfileobj(f_in, f_out)
 
     # delete source file if asked
     if delete_source:
         os.remove(filepath)
+
+    return compressed_path
 
 
 def gz_decompression(filepath, delete_source=True):

--- a/starling_sim/utils/utils.py
+++ b/starling_sim/utils/utils.py
@@ -1007,3 +1007,13 @@ def create_if_not_exists(folder):
         return True
     else:
         return False
+
+
+# git
+
+def get_git_revision_hash() -> str:
+    """
+    Get current git commit hash
+    """
+    return subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
+

--- a/starling_sim/utils/utils.py
+++ b/starling_sim/utils/utils.py
@@ -1011,9 +1011,9 @@ def create_if_not_exists(folder):
 
 # git
 
+
 def get_git_revision_hash() -> str:
     """
     Get current git commit hash
     """
-    return subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
-
+    return subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()

--- a/tools/generate_osm_graph.py
+++ b/tools/generate_osm_graph.py
@@ -7,7 +7,7 @@ They must be provided in the parameters file in the "topologies" field.
 Imports are realised using the OSMnX library, with the functions graph_from_place, graph_from_point
 and graph_from_polygon. The relevant information must be provided when running the command:
 
-- Import from **place**: provide a query and optionally a result number. You can test the results of a query at `<openstreetmap.org>`_.
+- Import from **place**: provide a query and optionally a result number. You can test the results of a query on `OpenStreetMap <https://www.openstreetmap.org>`_.
 
 - Import from **point**: provide a center point and a distance. The distance is used to draw a bbox around the center point.
 


### PR DESCRIPTION
improve run summary content and generation

added new contents to the run summary: Starling version and commit, run date, config content, output files and their information
the run summary file is now always generated, removed the 'generate_summary' option in parameters
the run summary file is now named "run_summary.json" instead of "{scenario}_summary.json"

(Close #56)