### PR TITLE
feat!: evaluation of max and estimated travel time

### DIFF
--- a/starling_sim/basemodel/agent/operators/operator.py
+++ b/starling_sim/basemodel/agent/operators/operator.py
@@ -44,7 +44,7 @@ class Operator(Agent):
             "max_travel_time": {
                 "type": ["string", "null"],
                 "title": "Max travel time formula",
-                "description": "Python expression used to evaluate the maximum travel time for each trip. "
+                "description": "Python expression used to evaluate the maximum travel time for each trip [seconds]. "
                                "It can use the trip direct travel time value by using the "
                                "following placeholder: {direct_travel_time}. The expression must evaluate to an "
                                "object that can be cast or rounded using Python int().",
@@ -724,7 +724,7 @@ class Operator(Agent):
 
     def compute_max_travel_time(self, direct_travel_time: int) -> Union[str, None]:
         """
-        Evaluate the max travel time formula to get a maximum travel time value.
+        Evaluate the max travel time formula to get a maximum travel time value [seconds].
 
         The formula is a Python expression, evaluated using the builtin eval function.
         It can use the direct travel time value by using the following placeholder: {direct_travel_time}

--- a/starling_sim/basemodel/agent/operators/operator.py
+++ b/starling_sim/basemodel/agent/operators/operator.py
@@ -45,12 +45,12 @@ class Operator(Agent):
                 "type": ["string", "null"],
                 "title": "Max travel time formula",
                 "description": "Python expression used to evaluate the maximum travel time for each trip [seconds]. "
-                               "It can use the trip direct travel time value by using the "
-                               "following placeholder: {direct_travel_time}. The expression must evaluate to an "
-                               "object that can be cast or rounded using Python int().",
+                "It can use the trip direct travel time value by using the "
+                "following placeholder: {direct_travel_time}. The expression must evaluate to an "
+                "object that can be cast or rounded using Python int().",
                 "examples": ["{direct_travel_time} * 1.5", "{direct_travel_time} + 900", "1800"],
-                "default": None
-            }
+                "default": None,
+            },
         },
     }
 
@@ -730,7 +730,7 @@ class Operator(Agent):
         It can use the direct travel time value by using the following placeholder: {direct_travel_time}
         It must return something that can be cast or rounded using int().
 
-        Examples (without the brackets): 
+        Examples (without the brackets):
             - "{direct_travel_time} * 1.5"
             - "{direct_travel_time} + 900"
             - "1800"
@@ -757,7 +757,9 @@ class Operator(Agent):
             if max_travel_time is not None:
                 max_travel_time = int(max_travel_time)
         except Exception:
-            msg = "Failed to evaluate the following formula for max travel time: {}".format(max_travel_time_formula)
+            msg = "Failed to evaluate the following formula for max travel time: {}".format(
+                max_travel_time_formula
+            )
             self.log_message(msg, 40)
             raise ValueError(msg)
 

--- a/starling_sim/basemodel/agent/operators/operator.py
+++ b/starling_sim/basemodel/agent/operators/operator.py
@@ -722,7 +722,7 @@ class Operator(Agent):
 
     # utils
 
-    def compute_max_travel_time(self, direct_travel_time: int) -> Union[str, None]:
+    def compute_max_travel_time(self, direct_travel_time: int) -> Union[int, None]:
         """
         Evaluate the max travel time formula to get a maximum travel time value [seconds].
 

--- a/starling_sim/basemodel/agent/operators/operator.py
+++ b/starling_sim/basemodel/agent/operators/operator.py
@@ -16,6 +16,7 @@ from starling_sim.utils.paths import (
 from starling_sim.utils.constants import STOP_POINT_POPULATION, ADD_STOPS_COLUMNS
 
 import pandas as pd
+from typing import Union
 
 
 class Operator(Agent):
@@ -39,6 +40,16 @@ class Operator(Agent):
                 "items": {"type": "string"},
                 "title": "GTFS routes to keep in the public transport simulation",
                 "description": "List of route ids that should be present in the simulation. If null, keep all routes.",
+            },
+            "max_travel_time": {
+                "type": ["string", "null"],
+                "title": "Max travel time formula",
+                "description": "Python expression used to evaluate the maximum travel time for each trip. "
+                               "It can use the trip direct travel time value by using the "
+                               "following placeholder: {direct_travel_time}. The expression must evaluate to an "
+                               "object that can be cast or rounded using Python int().",
+                "examples": ["{direct_travel_time} * 1.5", "{direct_travel_time} + 900", "1800"],
+                "default": None
             }
         },
     }
@@ -711,33 +722,43 @@ class Operator(Agent):
 
     # utils
 
-    def compute_travel_time_with_detour(direct_travel_time, max_detour):
+    def compute_max_travel_time(self, direct_travel_time: int) -> Union[str, None]:
         """
-        Compute the travel time of a trip with a given detour.
+        Evaluate the max travel time formula to get a maximum travel time value.
 
-        The deviated travel time can be used to compute a maximum acceptable
-        travel time, or an estimated travel time.
+        The formula is a Python expression, evaluated using the builtin eval function.
+        It can use the direct travel time value by using the following placeholder: {direct_travel_time}
+        It must return something that can be cast or rounded using int().
 
-        If the detour is a float, it is used as a multiplicand with the direct travel time.
-        If it is an integer, it is used as a constant (in seconds) added to the direct travel time.
+        Examples (without the brackets): 
+            - "{direct_travel_time} * 1.5"
+            - "{direct_travel_time} + 900"
+            - "1800"
 
-        :param direct_travel_time: direct travel time in seconds
-        :param max_detour: maximum detour, either as a multiplicand or as a constant, or None
+        :param direct_travel_time: value of the direct travel time (int)
 
-        :return: deviated travel time (can be a float or an int), or None if max detour is None
+        :return: value of the maximum travel time (int) or None if no constraint is applied
+        :raises: ValueError if the evaluation of the formula fails
         """
 
-        if isinstance(max_detour, float):
-            max_travel_time = direct_travel_time * max_detour
-        elif isinstance(max_detour, int):
-            max_travel_time = direct_travel_time + max_detour
-        elif max_detour is None:
-            max_travel_time = None
-        else:
-            raise ValueError(
-                "Unsupported type for max detour parameter : {}".format(type(max_detour))
-            )
+        # get formula from operation parameters
+        max_travel_time_formula = self.operationParameters["max_travel_time"]
+        if max_travel_time_formula is None:
+            return None
+
+        # format formula with direct travel time
+        formula = max_travel_time_formula.format(direct_travel_time=direct_travel_time)
+
+        try:
+            # evaluate formula with eval() builtin
+            max_travel_time = eval(formula)
+
+            # cast to integer if not None
+            if max_travel_time is not None:
+                max_travel_time = int(max_travel_time)
+        except Exception:
+            msg = "Failed to evaluate the following formula for max travel time: {}".format(max_travel_time_formula)
+            self.log_message(msg, 40)
+            raise ValueError(msg)
 
         return max_travel_time
-
-    compute_travel_time_with_detour = staticmethod(compute_travel_time_with_detour)

--- a/starling_sim/basemodel/output/kpis.py
+++ b/starling_sim/basemodel/output/kpis.py
@@ -190,7 +190,7 @@ class OdtWaitsKPI(KPI):
                         self.indicator_dict[self.KEY_DETOUR] += "-"
                         self.indicator_dict[self.KEY_DIRECT_TRIP] += "-"
                     self.indicator_dict[self.KEY_DETOUR] += str(request.waitSequence[1])
-                    self.indicator_dict[self.KEY_DIRECT_TRIP] += str(request.directTravelTime)
+                self.indicator_dict[self.KEY_DIRECT_TRIP] += str(request.directTravelTime)
 
             elif agent.id in pickup_agents:
                 request = event.pickups[pickup_agents.index(agent.id)]

--- a/starling_sim/schemas/parameters.schema.json
+++ b/starling_sim/schemas/parameters.schema.json
@@ -128,7 +128,7 @@
         "boolean",
         "object"
       ],
-      "default": true
+      "default": false
     },
     "seed": {
       "advanced": true,
@@ -150,6 +150,13 @@
       "title": "User routing parameters",
       "description": "These parameters are used in models including public and on-demand transport",
       "properties": {
+        "objective_type": {
+          "title": "Objective time type",
+          "description": "Define if the user is trying to 'depart after' or 'arrive before' the provided objective time",
+          "type": "string",
+          "enum": ["start_after", "arrive_before"],
+          "default": "start_after"
+        },
         "max_nearest_stops": {
           "title": "Maximum number of considered stops",
           "description": "Number of stops around origin and destination considered by the users when computing journeys",

--- a/starling_sim/schemas/starling_config.schema.json
+++ b/starling_sim/schemas/starling_config.schema.json
@@ -50,6 +50,13 @@
       "exclusiveMinimum": 0,
       "default": 240
     },
+    "estimated_detour": {
+      "title": "Estimated trip detour",
+      "description": "Used in some models to estimate a shared trip duration before proper planning. Multiplied to the trip direct travel time",
+      "type": "number",
+      "minimum": 1,
+      "default": 1.3
+    },
     "geojson_version": {
       "title": "GeoJSON output version",
       "description": "Format version of the GeoJSON output. If null, use the one specified in geojson_output.py.",

--- a/starling_sim/simulation_scenario.py
+++ b/starling_sim/simulation_scenario.py
@@ -7,7 +7,7 @@ import os
 import json
 from copy import deepcopy
 
-from starling_sim.utils.utils import json_load, validate_against_schema
+from starling_sim.utils.utils import json_load, add_defaults_and_validate
 from starling_sim.utils import paths
 from starling_sim.utils.config import config
 from starling_sim import __version__
@@ -104,7 +104,7 @@ class SimulationScenario:
 
         # parameters validation
         schema = json_load(paths.schemas_folder() + self.BASE_PARAM_SCHEMA)
-        validate_against_schema(self.parameters, schema)
+        self.parameters = add_defaults_and_validate(self.parameters, schema)
 
         # change date format from YYYY-MM-DD to YYYYMMDD
         if "date" in self.parameters:


### PR DESCRIPTION
replaced the former compute_travel_time_with_detour by compute_max_travel_time. Removed the 'max_detour' operation parameter and added 'max_travel_time' which is a Python expression for evaluating the max travel time (see Operator schema)

new 'estimated_detour' parameter in starling config, used to estimate a shared trip duration, by multiplying it to the direct travel time