### PR TITLE
feat!: improve operator's depots and add service status

### DIFF
--- a/docs/run/io.rst
+++ b/docs/run/io.rst
@@ -182,6 +182,7 @@ You can find here the correspondence between the most of the KPI fields and thei
     OccupationKPI.KEY_STOCK_TIME
     OccupationKPI.KEY_STOCK_DISTANCE
     OccupationKPI.KEY_MAX_STOCK
+    ServiceKPI.KEY_SERVICE_DURATION
     DestinationReachedKPI.KEY_DESTINATION_REACHED
     LeaveSimulationKPI.KEY_LEAVE_SIMULATION
 

--- a/starling_sim/basemodel/agent/operators/operator.py
+++ b/starling_sim/basemodel/agent/operators/operator.py
@@ -96,22 +96,18 @@ class Operator(Agent):
                 "items": {
                     "type": "object",
                     "properties": {
-                        "id": {
-                            "type": "string"
-                        },
+                        "id": {"type": "string"},
                         "coordinates": {
                             "type": "array",
                             "items": {"type": "number"},
                             "minItems": 2,
                             "maxItems": 2,
                         },
-                        "name": {
-                            "type": "string"
-                        }
+                        "name": {"type": "string"},
                     },
                     "required": ["id", "coordinates"],
                 },
-                "default": []
+                "default": [],
             },
             "extend_graph_with_stops": {
                 "advanced": True,
@@ -307,10 +303,7 @@ class Operator(Agent):
         """
         Return a dict mapping both stop points and depot points.
         """
-        return {
-            **self.stopPoints,
-            **self.depotPoints
-        }
+        return {**self.stopPoints, **self.depotPoints}
 
     # attributes initialisation methods
 
@@ -392,7 +385,9 @@ class Operator(Agent):
                 depot_modes = list(self.sim.environment.topologies.values())
             else:
                 depot_modes = list(self.mode.values())
-            position = self.sim.environment.nearest_node_in_modes([coordinates[1], coordinates[0]], depot_modes)
+            position = self.sim.environment.nearest_node_in_modes(
+                [coordinates[1], coordinates[0]], depot_modes
+            )
 
             # create depot as a StopPoint object and add it to depotPoints
             self.new_stop_point(position, depot_id, name, allow_existing=False, is_depot=True)
@@ -439,7 +434,14 @@ class Operator(Agent):
 
             self.new_stop_point(stop_position, stop_point_id, stop_point_name)
 
-    def new_stop_point(self, stop_point_position, stop_point_id, stop_point_name=None, allow_existing=True, is_depot=False):
+    def new_stop_point(
+        self,
+        stop_point_position,
+        stop_point_id,
+        stop_point_name=None,
+        allow_existing=True,
+        is_depot=False,
+    ):
         """
         Create or get existing StopPoint and add it to the operator stop points.
 

--- a/starling_sim/basemodel/agent/operators/operator.py
+++ b/starling_sim/basemodel/agent/operators/operator.py
@@ -361,9 +361,9 @@ class Operator(Agent):
                     depot_modes = list(self.sim.environment.topologies.values())
                 else:
                     depot_modes = list(self.mode.values())
-                position = self.sim.environment.nearest_node_in_modes(coord, depot_modes)
+                position = self.sim.environment.nearest_node_in_modes([coord[1], coord[0]], depot_modes)
                 depot = Station(
-                    self.sim, depot_id, position, mode=self.mode["fleet"], agent_type=None
+                    self.sim, depot_id, position, operator_id=self.id, mode=self.mode["fleet"], agent_type=None
                 )
                 self.depotPoints[depot_id] = depot
 

--- a/starling_sim/basemodel/agent/operators/operator.py
+++ b/starling_sim/basemodel/agent/operators/operator.py
@@ -407,21 +407,44 @@ class Operator(Agent):
             stop_point_name = row["stop_name"]
             stop_position = row["nearest_node"]
 
-            stop_point_population = self.sim.agentPopulation.new_population(STOP_POINT_POPULATION)
+            self.new_stop_point(stop_position, stop_point_id, stop_point_name)
 
-            # if the stop point already exists, get it from the stop point population
-            if stop_point_id in stop_point_population:
+    def new_stop_point(self, stop_point_position, stop_point_id, stop_point_name=None, allow_existing=True, is_depot=False):
+        """
+        Create or get existing StopPoint and add it to the operator stop points.
+
+        :param stop_point_id: new stop id
+        :param stop_point_position: new stop position
+        :param stop_point_name: new stop name
+        :param allow_existing: allow existence of a stop point with same id
+        :param is_depot: indicates if new stop point is a depot
+
+        :return: corresponding StopPoint object
+        """
+        stop_point_population = self.sim.agentPopulation.new_population(STOP_POINT_POPULATION)
+        # if the stop point already exists, get it from the stop point population
+        if stop_point_id in stop_point_population:
+            if allow_existing:
                 stop_point = stop_point_population[stop_point_id]
-
                 # no comparison between the two positions. The stops initialisation must be well ordered
-
-            # otherwise, create a new StopPoint object and add it to the population
             else:
-                stop_point = StopPoint(stop_position, stop_point_id, stop_point_name)
-                self.sim.agentPopulation.new_agent_in(stop_point, STOP_POINT_POPULATION)
+                raise ValueError("Stop point with id {} already exists !".format(stop_point_id))
 
-            # add the stop point to the operator stop points dict
+        # otherwise, create a new StopPoint object and add it to the population
+        else:
+            if stop_point_name is None:
+                stop_point = StopPoint(stop_point_position, stop_point_id)
+            else:
+                stop_point = StopPoint(stop_point_position, stop_point_id, stop_point_name)
+            self.sim.agentPopulation.new_agent_in(stop_point, STOP_POINT_POPULATION)
+
+        # add the stop point to the relevant operator dict
+        if is_depot:
+            self.depotPoints[stop_point.id] = stop_point
+        else:
             self.stopPoints[stop_point.id] = stop_point
+
+        return stop_point
 
     def init_trips(self):
         """

--- a/starling_sim/basemodel/agent/vehicles/service_vehicle.py
+++ b/starling_sim/basemodel/agent/vehicles/service_vehicle.py
@@ -4,7 +4,7 @@ from starling_sim.basemodel.trace.events import (
     RequestEvent,
     StopEvent,
     StaffOperationEvent,
-    ServiceEvent
+    ServiceEvent,
 )
 from starling_sim.basemodel.agent.requests import Stop
 from starling_sim.utils.utils import PlanningChange
@@ -42,8 +42,8 @@ class ServiceVehicle(Vehicle):
             "depot": {
                 "title": "Depot",
                 "description": "Id of the associated depot of the service vehicle",
-                "type": "string"
-            }
+                "type": "string",
+            },
         },
         "required": ["operator_id"],
     }
@@ -133,9 +133,11 @@ class ServiceVehicle(Vehicle):
 
         :param new_status_value: new service status value
         """
-        if  new_status_value not in [SERVICE_INIT, SERVICE_UP, SERVICE_PAUSE, SERVICE_END]:
+        if new_status_value not in [SERVICE_INIT, SERVICE_UP, SERVICE_PAUSE, SERVICE_END]:
             raise ValueError("Unsupported service status value: " + str(new_status_value))
-        self.trace_event(ServiceEvent(self.sim.scheduler.now(), self.serviceStatus, new_status_value))
+        self.trace_event(
+            ServiceEvent(self.sim.scheduler.now(), self.serviceStatus, new_status_value)
+        )
         self.serviceStatus = new_status_value
 
     # stop processing

--- a/starling_sim/basemodel/agent/vehicles/service_vehicle.py
+++ b/starling_sim/basemodel/agent/vehicles/service_vehicle.py
@@ -49,8 +49,17 @@ class ServiceVehicle(Vehicle):
         operator_id,
         dwell_time=30,
         trip_id=None,
+        depot_id=None,
         **kwargs
     ):
+        operator = simulation_model.agentPopulation.get_agent(operator_id)
+        # place service vehicles at depot if provided
+        if depot_id is not None:
+            depot = operator.depotPoints[depot_id]
+            origin = depot.position
+        else:
+            depot = None
+
         super().__init__(simulation_model, agent_id, origin, seats, **kwargs)
 
         # list of trip ids to be realised by the service vehicle (chronological order)
@@ -59,11 +68,14 @@ class ServiceVehicle(Vehicle):
         # id of the trip realised by the service vehicle, used to match user stops
         self.tripId = trip_id
 
+        # vehicle depot
+        self.depot = depot
+
         # halt duration while processing a stop
         self.dwellTime = dwell_time
 
         # service operator, managing the fleet
-        self.operator = self.sim.agentPopulation.get_agent(operator_id)
+        self.operator = operator
 
         # planning of the service vehicle, consists in a list of Stop objects
         self.planning = []

--- a/starling_sim/basemodel/agent/vehicles/service_vehicle.py
+++ b/starling_sim/basemodel/agent/vehicles/service_vehicle.py
@@ -8,6 +8,8 @@ from starling_sim.basemodel.trace.events import (
 )
 from starling_sim.basemodel.agent.requests import Stop
 from starling_sim.utils.utils import PlanningChange
+from starling_sim.utils.constants import SERVICE_INIT, SERVICE_UP, SERVICE_PAUSE, SERVICE_END
+
 
 from copy import copy
 
@@ -40,6 +42,11 @@ class ServiceVehicle(Vehicle):
         },
         "required": ["operator_id"],
     }
+
+    SERVICE_INIT = SERVICE_INIT
+    SERVICE_UP = SERVICE_UP
+    SERVICE_PAUSE = SERVICE_PAUSE
+    SERVICE_END = SERVICE_END
 
     def __init__(
         self,
@@ -87,8 +94,8 @@ class ServiceVehicle(Vehicle):
         # event triggered to send a signal to service vehicle
         self.signalEvent_ = self.sim.scheduler.new_event_object()
 
-        # service status (see update_service_status method)
-        self.serviceStatus = "INIT"
+        # service status
+        self.serviceStatus = SERVICE_INIT
 
     # signaling
 
@@ -119,15 +126,11 @@ class ServiceVehicle(Vehicle):
         """
         Update the value of the vehicle's service status and trace a ServiceEvent.
 
-        Possible values are:
-            - INIT: Service has not started yet
-            - UP: Service has started and is up
-            - PAUSE: Service has started but is paused
-            - END: Service has ended
+        See possible values in starling_sim.utils.constants
 
         :param new_status_value: new service status value
         """
-        if  new_status_value not in ["INIT", "UP", "PAUSE", "END"]:
+        if  new_status_value not in [SERVICE_INIT, SERVICE_UP, SERVICE_PAUSE, SERVICE_END]:
             raise ValueError("Unsupported service status value: " + str(new_status_value))
         self.trace_event(ServiceEvent(self.sim.scheduler.now(), self.serviceStatus, new_status_value))
         self.serviceStatus = new_status_value

--- a/starling_sim/basemodel/agent/vehicles/service_vehicle.py
+++ b/starling_sim/basemodel/agent/vehicles/service_vehicle.py
@@ -39,6 +39,11 @@ class ServiceVehicle(Vehicle):
                 "description": "ID of the operator managing this agent",
                 "type": "string",
             },
+            "depot": {
+                "title": "Depot",
+                "description": "Id of the associated depot of the service vehicle",
+                "type": "string"
+            }
         },
         "required": ["operator_id"],
     }
@@ -57,16 +62,14 @@ class ServiceVehicle(Vehicle):
         operator_id,
         dwell_time=30,
         trip_id=None,
-        depot_id=None,
+        depot=None,
         **kwargs
     ):
         operator = simulation_model.agentPopulation.get_agent(operator_id)
         # place service vehicles at depot if provided
-        if depot_id is not None:
-            depot = operator.depotPoints[depot_id]
+        if depot is not None:
+            depot = operator.depotPoints[depot]
             origin = depot.position
-        else:
-            depot = None
 
         super().__init__(simulation_model, agent_id, origin, seats, **kwargs)
 

--- a/starling_sim/basemodel/agent/vehicles/service_vehicle.py
+++ b/starling_sim/basemodel/agent/vehicles/service_vehicle.py
@@ -481,3 +481,24 @@ class ServiceVehicle(Vehicle):
             idle_duration = self.sim.scheduler.now() - start_time
             if idle_duration > 0:
                 self.trace_event(IdleEvent(self.sim.scheduler.now(), idle_duration))
+
+                return idle_duration
+
+        return 0
+
+    def return_to_depot_(self, service_status=None):
+        """
+        Move to service vehicle depot.
+
+        :param service_status: optional new service status value
+        """
+        # get depot position
+        if self.depot is None:
+            self.log_message("No depot to return to")
+        else:
+            self.tempDestination = self.depot.position
+            yield self.execute_process(self.move_())
+
+        # optionally update service status value
+        if service_status is not None:
+            self.update_service_status(service_status)

--- a/starling_sim/basemodel/algorithms/dispatcher.py
+++ b/starling_sim/basemodel/algorithms/dispatcher.py
@@ -138,13 +138,13 @@ class Dispatcher(ABC):
         matrix = np.zeros((len(stop_points), len(stop_points)))
 
         for i in range(len(stop_points)):
-            origin = self.operator.stopPoints[stop_points[i]].position
+            origin = self.operator.servicePoints[stop_points[i]].position
             _, lengths = self.sim.environment.topologies[mode].compute_dijkstra_path(
                 origin, None, dimension
             )
 
             for j in range(len(stop_points)):
-                matrix[i, j] = int(lengths[self.operator.stopPoints[stop_points[j]].position])
+                matrix[i, j] = int(lengths[self.operator.servicePoints[stop_points[j]].position])
 
         if dimension == "time":
             matrix = matrix.astype(int)

--- a/starling_sim/basemodel/output/geojson_output.py
+++ b/starling_sim/basemodel/output/geojson_output.py
@@ -223,8 +223,8 @@ class GeojsonOutput1(GeojsonOutput):
             self.current_feature = create_point_feature(self, element)
 
         elif isinstance(element, Operator):
-            if len(element.stopPoints.values()) != 0:
-                self.add_population_features(list(element.stopPoints.values()))
+            if len(element.servicePoints.values()) != 0:
+                self.add_population_features(list(element.servicePoints.values()))
 
             self.current_element = element
             if element.serviceZone is not None:
@@ -258,8 +258,8 @@ class GeojsonOutput0(GeojsonOutput):
         self.current_feature = None
 
         if isinstance(element, Operator):
-            if len(element.stopPoints.values()) != 0:
-                self.add_population_features(list(element.stopPoints.values()))
+            if len(element.servicePoints.values()) != 0:
+                self.add_population_features(list(element.servicePoints.values()))
 
             self.current_element = element
             if element.serviceZone is not None:

--- a/starling_sim/basemodel/output/kpis.py
+++ b/starling_sim/basemodel/output/kpis.py
@@ -430,7 +430,7 @@ class OccupationKPI(KPI):
         """
 
         # compute time spent with last stock
-        duration = timestamp - self.previousTime
+        duration = int(timestamp - self.previousTime)
 
         # add time to relevant time count
         if self.currentStock == 0:

--- a/starling_sim/basemodel/output/kpis.py
+++ b/starling_sim/basemodel/output/kpis.py
@@ -662,6 +662,37 @@ class ChargeKPI(KPI):
                 get_direction_of_trip(self.trips, trip_id)
             )
 
+class ServiceKPI(KPI):
+    """
+    This KPI describes the service time of a vehicle.
+    """
+
+    #: **serviceDuration**: vehicle service duration [seconds]
+    KEY_SERVICE_DURATION = "serviceDuration"
+
+    def __init__(self):
+        super().__init__()
+        self.serviceStart = None
+        self.serviceEnd = None
+        self.keys = [self.KEY_SERVICE_DURATION]
+
+    def new_indicator_dict(self):
+        self.indicator_dict = {
+            self.KEY_SERVICE_DURATION: "NA"
+        }
+
+    def update(self, event, agent):
+
+        if isinstance(event, ServiceEvent):
+            if event.former == "INIT" and event.new == "UP":
+                self.serviceStart = event.timestamp
+            elif event.former == "UP" and event.new == "END":
+                self.serviceEnd = event.timestamp
+
+        if isinstance(event, LeaveSimulationEvent):
+            if self.serviceStart is not None and self.serviceEnd is not None:
+                self.indicator_dict[self.KEY_SERVICE_DURATION] = self.serviceEnd - self.serviceStart
+
 
 class TransferKPI(KPI):
     """

--- a/starling_sim/basemodel/output/kpis.py
+++ b/starling_sim/basemodel/output/kpis.py
@@ -1,6 +1,12 @@
 from starling_sim.basemodel.trace.events import *
 from starling_sim.basemodel.agent.requests import UserStop, StopPoint, StationRequest
-from starling_sim.utils.constants import PUBLIC_TRANSPORT_TYPE, SERVICE_INIT, SERVICE_UP, SERVICE_PAUSE, SERVICE_END
+from starling_sim.utils.constants import (
+    PUBLIC_TRANSPORT_TYPE,
+    SERVICE_INIT,
+    SERVICE_UP,
+    SERVICE_PAUSE,
+    SERVICE_END,
+)
 
 
 class KPI:
@@ -662,6 +668,7 @@ class ChargeKPI(KPI):
                 get_direction_of_trip(self.trips, trip_id)
             )
 
+
 class ServiceKPI(KPI):
     """
     This KPI describes the service time of a vehicle.
@@ -677,12 +684,9 @@ class ServiceKPI(KPI):
         self.keys = [self.KEY_SERVICE_DURATION]
 
     def new_indicator_dict(self):
-        self.indicator_dict = {
-            self.KEY_SERVICE_DURATION: "NA"
-        }
+        self.indicator_dict = {self.KEY_SERVICE_DURATION: "NA"}
 
     def update(self, event, agent):
-
         if isinstance(event, ServiceEvent):
             if event.new == SERVICE_UP:
                 self.start_service(event.timestamp)
@@ -716,6 +720,7 @@ class ServiceKPI(KPI):
             else:
                 self.totalServiceDuration += duration
             self.currentServiceStart = None
+
 
 class TransferKPI(KPI):
     """

--- a/starling_sim/basemodel/output/output_factory.py
+++ b/starling_sim/basemodel/output/output_factory.py
@@ -4,7 +4,6 @@ from starling_sim.utils.config import config
 from starling_sim.utils.constants import RUN_SUMMARY_FILENAME
 
 import logging
-import os
 
 
 class OutputFactory:
@@ -15,7 +14,7 @@ class OutputFactory:
     e.g. writing a json containing all the simulation data
     """
 
-    GENERATION_ERROR_FORMAT = "Error while generating {} output"
+    GENERATION_ERROR_FORMAT = "Error while generating {} output: {}"
 
     def __init__(self):
         """
@@ -137,8 +136,8 @@ class OutputFactory:
         if simulation_model.scenario["traces_output"]:
             try:
                 self.generate_trace_output(simulation_model)
-            except:
-                logging.warning(self.GENERATION_ERROR_FORMAT.format("traces"))
+            except Exception as e:
+                logging.warning(self.GENERATION_ERROR_FORMAT.format("traces", e))
 
         # kpi output
         if simulation_model.scenario["kpi_output"]:
@@ -149,8 +148,8 @@ class OutputFactory:
         if simulation_model.scenario["visualisation_output"]:
             try:
                 self.generate_geojson_output(simulation_model)
-            except:
-                logging.warning(self.GENERATION_ERROR_FORMAT.format("visualisation"))
+            except Exception as e:
+                logging.warning(self.GENERATION_ERROR_FORMAT.format("visualisation", e))
 
         # run summary output
         self.generate_run_summary(simulation_model.scenario)
@@ -176,8 +175,8 @@ class OutputFactory:
         for kpi_output in self.kpi_outputs:
             try:
                 kpi_output.write_kpi_table()
-            except:
-                logging.warning(self.GENERATION_ERROR_FORMAT.format(kpi_output.name + " kpi"))
+            except Exception as e:
+                logging.warning(self.GENERATION_ERROR_FORMAT.format(kpi_output.name + " kpi", e))
 
     def generate_trace_output(self, simulation_model):
         """

--- a/starling_sim/basemodel/trace/events.py
+++ b/starling_sim/basemodel/trace/events.py
@@ -175,6 +175,20 @@ class IdleEvent(Event):
         return super().__str__() + "idleDuration={}".format(self.duration)
 
 
+class ServiceEvent(Event):
+    """
+    This event describes a status change of an agent service.
+    """
+    def __init__(self, time, former_status, new_status, message=""):
+        super().__init__(time, message)
+        # former and new status values
+        self.former = former_status
+        self.new = new_status
+
+    def __str__(self):
+        return super().__str__() + "formerStatus={}, newStatus={}".format(self.former, self.new)
+
+
 class RequestEvent(Event):
     """
     This event describes a user request

--- a/starling_sim/basemodel/trace/events.py
+++ b/starling_sim/basemodel/trace/events.py
@@ -179,6 +179,7 @@ class ServiceEvent(Event):
     """
     This event describes a status change of an agent service.
     """
+
     def __init__(self, time, former_status, new_status, message=""):
         super().__init__(time, message)
         # former and new status values

--- a/starling_sim/utils/constants.py
+++ b/starling_sim/utils/constants.py
@@ -35,6 +35,17 @@ BASE_LEAVING_CODES = {
     SIM_ERROR_LEAVE: "Simulation error",
 }
 
+# service statuses
+
+#: Status used when service has not started yet
+SERVICE_INIT = "INIT"
+#: Status used when service started and is up
+SERVICE_UP = "UP"
+#: Status used when service has started but is paused
+SERVICE_PAUSE = "PAUSE"
+#: Status used when service has ended
+SERVICE_END = "END"
+
 # filename formats
 
 #: filename of the run summary file


### PR DESCRIPTION
- Depot points
BREAKING CHANGE: Changed specification of Operator's depot_points parameter (see schema)
Depot points are now StopPoint instances but are stored in a separate depotPoints attribute
New Operator property, servicePoints. allows accessing both stopPoints and depotPoints, for instance when computing dispatch paths.
Service vehicles can now be linked to one of their operator's depots, providing its id in the 'depot' parameter. If a depot is provided, the service vehicle origin is set to the depot's position.

- Service status
New ServiceVehicle attribute serviceStatus. Indicates the service status of this individual vehicle (init, up, pause, end). Possible values are listed in constants.py and in the ServiceVehicle class attributes.
New ServiceEvent signaling a change in the service status of a service vehicle.
New ServiceVehicle method for returning to depot.
New KPI ServiceKPI that allows computing the total service time of a service vehicle, using ServiceEvent.