### PR TITLE
feat(topology): improve default speed fetch with OSMNetwork

### DIFF
--- a/starling_sim/basemodel/topology/osm_network.py
+++ b/starling_sim/basemodel/topology/osm_network.py
@@ -81,6 +81,8 @@ class OSMNetwork(Topology):
         # differentiate speeds among the link types
         if d["highway"] in self.speeds:
             speed = self.speeds[d["highway"]]["speed"]
+        elif d["highway"].endswith("_link") and d["highway"][:-5] in self.speeds:
+            speed = self.speeds[d["highway"][:-5]]["speed"]
         else:
             speed = self.speeds["other"]["speed"]
 


### PR DESCRIPTION
For arcs tagged with highway=*_link, try using the speed of the raw highway type (without "_link"). For instance, if an arc is tagged highway=primary_link and "primary_link" is not specified in speeds, try using "primary" key.