### PR TITLE
feat(io): agents can now be duplicated using 'duplicates' attribute

### DIFF
--- a/starling_sim/basemodel/agent/agent.py
+++ b/starling_sim/basemodel/agent/agent.py
@@ -32,6 +32,12 @@ class Agent(Traced):
                 "description": "Road network used by the agent",
             },
             "icon": {"type": "string", "title": "Agent icon", "description": "Display icon"},
+            "duplicates": {
+                "title": "Agent duplicates",
+                "description": "Generate duplicates of this agent",
+                "type": "integer",
+                "minimum": 1
+            }
         },
         "required": ["agent_id", "agent_type", "mode", "icon"],
     }


### PR DESCRIPTION

See new entry in Agent schema.
Duplicated agent ids are generated using the original id and the duplicate index.