### PR TITLE
ci: update gh-action-pypi-publish to release@v1

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -48,6 +48,6 @@ jobs:
           .
       - name: Publish distribution 📦 to PyPI
         if: ${{ steps.release.outputs.release_created }}
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Following deprecation of @master