### PR TITLE
feat: edge speeds improvements

### DIFF
--- a/starling_sim/basemodel/agent/operators/operator.py
+++ b/starling_sim/basemodel/agent/operators/operator.py
@@ -410,7 +410,7 @@ class Operator(Agent):
 
             # infer depot position according to service modes
             if self.mode is None:
-                depot_modes = list(self.sim.environment.topologies.values())
+                depot_modes = self.sim.environment.modes
             else:
                 depot_modes = list(self.mode.values())
             position = self.sim.environment.nearest_node_in_modes(

--- a/starling_sim/basemodel/algorithms/dispatcher.py
+++ b/starling_sim/basemodel/algorithms/dispatcher.py
@@ -139,7 +139,7 @@ class Dispatcher(ABC):
 
         for i in range(len(stop_points)):
             origin = self.operator.servicePoints[stop_points[i]].position
-            _, lengths = self.sim.environment.topologies[mode].compute_dijkstra_path(
+            _, lengths = self.sim.environment[mode].compute_dijkstra_path(
                 origin, None, dimension
             )
 

--- a/starling_sim/basemodel/algorithms/pal_zhang_GCH.py
+++ b/starling_sim/basemodel/algorithms/pal_zhang_GCH.py
@@ -324,7 +324,7 @@ class PalZhangGCH(Algorithm):
                 continue
 
             # compute travel time to other stations
-            travel_time[station.id] = self.sim.environment.topologies[
+            travel_time[station.id] = self.sim.environment[
                 self.vehicle_mode
             ].shortest_path_length(current_station.position, station.position, None)
 
@@ -365,7 +365,7 @@ class PalZhangGCH(Algorithm):
                 origin, self.operator.stations.values(), 1
             )[0]
 
-            travel_time = self.sim.environment.topologies["walk"].shortest_path_length(
+            travel_time = self.sim.environment["walk"].shortest_path_length(
                 origin, origin_station.position, None
             )
             origin_station_time = origin_time + travel_time
@@ -376,7 +376,7 @@ class PalZhangGCH(Algorithm):
                 destination, self.operator.stations.values(), 1
             )[0]
 
-            travel_time = self.sim.environment.topologies[
+            travel_time = self.sim.environment[
                 self.operator.mode["fleet"]
             ].shortest_path_length(origin_station.position, destination_station.position, None)
 

--- a/starling_sim/basemodel/environment/environment.py
+++ b/starling_sim/basemodel/environment/environment.py
@@ -55,7 +55,7 @@ class Environment:
                 topology = OSMNetwork(
                     mode,
                     network_file=osm_graphs_folder() + network_file,
-                    speed_file=graph_speeds_folder() + speeds_file,
+                    speed_file=graph_speeds_folder() + speeds_file if isinstance(speeds_file, str) else speeds_file,
                     store_paths=store,
                     weight_class=weight_class,
                 )

--- a/starling_sim/basemodel/input/dynamic_input.py
+++ b/starling_sim/basemodel/input/dynamic_input.py
@@ -594,7 +594,7 @@ class DynamicInput(Traced):
             input_value = None
 
         # get the list of topologies and the global dict of modes
-        topologies = list(self.sim.environment.topologies.keys())
+        topologies = self.sim.environment.modes
         agent_type_modes = self.sim.modes
 
         # get the keyword to replace

--- a/starling_sim/basemodel/output/feature_factory.py
+++ b/starling_sim/basemodel/output/feature_factory.py
@@ -99,7 +99,7 @@ def get_element_line_string(geojson_output, element):
             mode = event.mode
 
             # get the list of route localisations and timestamps
-            route_positions, route_timestamps = geojson_output.graphs[mode].route_event_trace(
+            route_positions, route_timestamps = geojson_output.sim.environment[mode].route_event_trace(
                 event, time_limit=geojson_output.sim.scenario["limit"]
             )
 
@@ -113,11 +113,11 @@ def get_element_line_string(geojson_output, element):
             mode = event.mode
 
             # add it to the agent's lists
-            localisations.append(geojson_output.graphs[mode].position_localisation(event.origin))
+            localisations.append(geojson_output.sim.environment[mode].position_localisation(event.origin))
             timestamps.append(event.timestamp)
 
             localisations.append(
-                geojson_output.graphs[mode].position_localisation(event.destination)
+                geojson_output.sim.environment[mode].position_localisation(event.destination)
             )
             timestamps.append(event.timestamp + event.duration)
 

--- a/starling_sim/basemodel/output/geojson_output.py
+++ b/starling_sim/basemodel/output/geojson_output.py
@@ -72,9 +72,6 @@ class GeojsonOutput(ABC):
         # simulation model from which information is extracted
         self.sim = None
 
-        # dict of the simulation topologies
-        self.graphs = None
-
         # construction of the output structure as a FeatureCollection
 
         # dict giving the information factories for each agent type
@@ -109,7 +106,6 @@ class GeojsonOutput(ABC):
         """
 
         self.sim = simulation_model
-        self.graphs = simulation_model.environment.topologies
         self.features = []
         self.filename = filename
         self.folder = folder

--- a/starling_sim/basemodel/output/kpis.py
+++ b/starling_sim/basemodel/output/kpis.py
@@ -268,7 +268,7 @@ class MoveKPI(KPI):
         super().__init__(**kwargs)
 
     def _indicators_setup(self, simulation_model):
-        self.modes = list(simulation_model.environment.topologies.keys())
+        self.modes = simulation_model.environment.modes
 
     def _init_keys(self):
         keys = []

--- a/starling_sim/basemodel/simulation_model.py
+++ b/starling_sim/basemodel/simulation_model.py
@@ -251,8 +251,8 @@ class SimulationModel:
         self.scenario.set_stat("execution_time", duration)
 
         shortest_path_count = 0
-        for topology in self.environment.topologies.values():
-            shortest_path_count += topology.shortest_path_count
+        for mode in self.environment.modes:
+            shortest_path_count += self.environment[mode].shortest_path_count
         self.scenario.set_stat("shortest_paths", shortest_path_count)
 
     def generate_output(self):

--- a/starling_sim/basemodel/topology/empty_network.py
+++ b/starling_sim/basemodel/topology/empty_network.py
@@ -22,7 +22,6 @@ class EmptyNetwork(Topology):
         super().__init__(transport_mode, weight_class=weight_class, store_paths=store_paths)
 
         self.graph = None
-        self.speeds = None
 
     def init_graph(self):
         # initialise an empty graph object

--- a/starling_sim/basemodel/topology/network_speeds.py
+++ b/starling_sim/basemodel/topology/network_speeds.py
@@ -1,0 +1,116 @@
+from starling_sim.utils.utils import json_load
+
+from abc import ABC, abstractmethod
+import pandas as pd
+
+
+class NetworkEdgeSpeed(ABC):
+    """
+    Abstract class for speed evaluation on topologies.
+    """
+    
+    def __init__(self):
+        # data structure containing the information used to evaluate speeds
+        self._speeds_data = None
+
+    @property
+    def speeds_data(self):
+        """
+        Access the speeds data structure
+        """
+        return self._speeds_data
+
+    @abstractmethod
+    def __call__(self, u, v, d) -> float:
+        """
+        Get the edge's speed from the data stored in self._speeds_data
+
+        :param u: origin node
+        :param v: destination node
+        :param d: edge data
+
+        :return: speed in km/h
+        """
+        pass
+
+
+class ConstantSpeed(NetworkEdgeSpeed):
+    """
+    Evaluate a constant speed independently of the edge.
+    """
+    def __init__(self, speed: float):
+        super().__init__()
+        self._speeds_data = speed
+        
+    def __call__(self, u, v, d) -> float:
+        return self._speeds_data
+
+
+class SpeedByHighwayType(NetworkEdgeSpeed):
+    """
+    Evaluate the edge speed based on its "highway" tag.
+
+    This class uses a speed mapper that maps "highway" tag values to speed values.
+    The mapper has the following format: { <tag>: { "speed": <speed_value> } }.
+
+    If a list of tags is provided, use the first one.
+    If the tag ends with '_links' and is not found in the speed mapper,
+    look for the tag value without the '_link' suffix.
+    If the tag is not found in the mapper, use the 'other' value of the mapper.
+    """
+    def __init__(self, speeds_json_file: str):
+        """
+        :param speeds_json_file: path to a json file containing the speed mapper
+        """
+        super().__init__()
+        self._speeds_datas = json_load(speeds_json_file)
+    
+    def __call__(self, u, v, d) -> float:
+        # choose the first tag if several are provided
+        if isinstance(d["highway"], list):
+            d["highway"] = d["highway"][0]
+
+        # differentiate speeds among the link types
+        if d["highway"] in self._speeds_datas:
+            speed = self._speeds_datas[d["highway"]]["speed"]
+        elif d["highway"].endswith("_link") and d["highway"][:-5] in self._speeds_datas:
+            speed = self._speeds_datas[d["highway"][:-5]]["speed"]
+        else:
+            speed = self._speeds_datas["other"]["speed"]
+            
+        return speed
+
+
+class SpeedByEdge(NetworkEdgeSpeed):
+    """
+    Evaluate speed individually for each network edge.
+
+    This class uses a mapper that maps (origin, destination) tuples to speed values.
+    The mapper is read from a CSV file that contains "origin", "destination" and "speed" columns.
+
+    The mapper must contain exactly one value for each (directed) edge of the graph.
+    """
+    def __init__(self, speeds_table_file: str):
+        super().__init__()
+
+        speeds_csv = pd.read_csv(speeds_table_file)
+        assert set(speeds_csv.columns) >= {"origin", "destination", "speed"}, (
+            f"Missing columns in speed file {speeds_table_file}. "
+            f"Expected columns are ['origin', 'destination', 'speed']")
+
+        speeds_dict = dict()
+        for _, row in speeds_csv.iterrows():
+            od = (row["origin"], row["destination"])
+            assert od not in speeds_dict, f"Several speed values found for edge: {od[0]} -> {od[1]}"
+
+            speeds_dict[od] = row["speed"]
+            
+        self._speeds_datas = speeds_dict
+            
+    def __call__(self, u, v, d) -> float:
+        od = (u, v)
+        if od not in self._speeds_datas:
+            raise ValueError(f"Missing speed value for edge: {u} -> {v}")
+        return self._speeds_datas[od]
+        
+    

--- a/starling_sim/basemodel/topology/network_speeds.py
+++ b/starling_sim/basemodel/topology/network_speeds.py
@@ -56,7 +56,7 @@ class SpeedByHighwayType(NetworkEdgeSpeed):
     If a list of tags is provided, use the first one.
     If the tag ends with '_links' and is not found in the speed mapper,
     look for the tag value without the '_link' suffix.
-    If the tag is not found in the mapper, use the 'other' value of the mapper.
+    If the tag is still not found in the mapper, use the 'other' value of the mapper.
     """
     def __init__(self, speeds_json_file: str):
         """

--- a/starling_sim/schemas/parameters.schema.json
+++ b/starling_sim/schemas/parameters.schema.json
@@ -38,7 +38,7 @@
           "description": "Array of two string items, the network file and the speeds file, or null to generate an empty graph",
           "type": ["array", "null"],
           "items": {
-            "type": "string"
+            "type": ["string", "number"]
           },
           "minItems": 2,
           "maxItems": 3

--- a/starling_sim/schemas/parameters.schema.json
+++ b/starling_sim/schemas/parameters.schema.json
@@ -35,13 +35,43 @@
       "description": "Files for initialising the topologies",
       "properties": {
         "additional_properties": {
-          "description": "Array of two string items, the network file and the speeds file, or null to generate an empty graph",
-          "type": ["array", "null"],
-          "items": {
-            "type": ["string", "number"]
-          },
-          "minItems": 2,
-          "maxItems": 3
+          "description": "Object containing network initialisation information, or null to generate an empty graph",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type":  "object",
+              "properties": {
+                "graph": {
+                  "description": "Name of the file containing the network graph describing the topology, stored in the graph folder",
+                  "type": "string"
+                },
+                "speeds": {
+                  "description": "Name of the file containing the network speeds (stored in the speeds folder) or a number describing a constant speed for all network edges",
+                  "type": ["string", "number"]
+                },
+                "weight": {
+                  "description": "Key describing pointing to the class to evaluate the weight on network edges (see topology.py::NETWORK_WEIGHT_CLASSES)",
+                  "type": "string"
+                },
+                "network_class": {
+                  "description": "Topology subclass used for representing this network",
+                  "type": "string"
+                }
+              },
+              "required": ["graph", "speeds"]
+            },
+            {
+              "description": "[DEPRECATED] Array of two string items, the network file and the speeds file, or null to generate an empty graph",
+              "type": "array",
+              "items": {
+                "type": ["string", "number"]
+              },
+              "minItems": 2,
+              "maxItems": 3
+            }
+          ]
         }
       },
       "required": ["walk"]

--- a/tests/simulation_test_data/models/FF_VS/example_nantes/inputs/Params.json
+++ b/tests/simulation_test_data/models/FF_VS/example_nantes/inputs/Params.json
@@ -10,7 +10,13 @@
     "dynamic_input_file": "users_nantes.geojson",
     "init_input_file": "ff_bikes_nantes.geojson",
     "topologies": {
-        "walk": ["SGwalk_Nantes.graphml.bz2", "speeds_walk.json"],
-        "bike": ["SGbike_Nantes.graphml.bz2", "speeds_bike.json"]
+        "walk": {
+            "graph": "SGwalk_Nantes.graphml.bz2",
+            "speeds": "speeds_walk.json"
+        },
+        "bike": {
+            "graph": "SGbike_Nantes.graphml.bz2",
+            "speeds": "speeds_bike.json"
+        }
     }
 }

--- a/tests/simulation_test_data/models/SB_VS/example_nantes/inputs/Params.json
+++ b/tests/simulation_test_data/models/SB_VS/example_nantes/inputs/Params.json
@@ -10,7 +10,13 @@
     "dynamic_input_file": "users_nantes.geojson",
     "init_input_file": "stations_nantes.geojson",
     "topologies": {
-        "walk": ["SGwalk_Nantes.graphml.bz2", "speeds_walk.json"],
-        "bike": ["SGbike_Nantes.graphml.bz2", "speeds_bike.json"]
+        "walk": {
+            "graph": "SGwalk_Nantes.graphml.bz2",
+            "speeds": "speeds_walk.json"
+        },
+        "bike": {
+            "graph": "SGbike_Nantes.graphml.bz2",
+            "speeds": "speeds_bike.json"
+        }
     }
 }

--- a/tests/simulation_test_data/models/SB_VS_R/example_nantes/inputs/Params.json
+++ b/tests/simulation_test_data/models/SB_VS_R/example_nantes/inputs/Params.json
@@ -9,9 +9,18 @@
     "events_output": true,
     "dynamic_input_file": "users_nantes.geojson",
     "init_input_file": ["operator.geojson", "operated_stations_nantes.geojson"],
-    "topologies": {
-        "walk": ["SGwalk_Nantes.graphml.bz2", "speeds_walk.json"],
-        "bike": ["SGbike_Nantes.graphml.bz2", "speeds_bike.json"],
-        "drive": ["SGdrive_Nantes.graphml.bz2", "speeds_drive.json"]
+        "topologies": {
+        "walk": {
+            "graph": "SGwalk_Nantes.graphml.bz2",
+            "speeds": "speeds_walk.json"
+        },
+        "bike": {
+            "graph": "SGbike_Nantes.graphml.bz2",
+            "speeds": "speeds_bike.json"
+        },
+        "drive" : {
+            "graph": "SGdrive_Nantes.graphml.bz2",
+            "speeds": "speeds_drive.json"
+        }
     }
 }


### PR DESCRIPTION
## Topologies specification

Changed the specification of topologies in the simulation parameters. 'topologies' parameter should now look like this:
```json
    "topologies": {
        "walk": {
            "graph": "SGwalk_Nantes.graphml.bz2",
            "speeds": "speeds_walk.json"
        },
        "bike": {
            "graph": "SGbike_Nantes.graphml.bz2",
            "speeds": "speeds_bike.json"
        }
    }
```
See updated schema for complete specification.
Former specification using arrays still works but is now deprecated.

## Speeds from CSV file

Users can now provide a CSV file instead of a JSON for speeds definition.

The CSV file should contain columns "origin", "destination" and "speed". "origin" and "destination" are node ids that define the edge, and "speed" its speed value in km/h.
The table should contain exactly one entry for each edge of the provided graph.

This allows using output from packages like [Aequilibrae](https://aequilibrae.com/latest/home.html) to define individual edge speeds.

## Constant speed

Users can also provide a float or integer in place of a speeds file. In this case, this value (in km/h) will be used as the speed for all edges of the graph.

## Code refactoring around the Environment class

Refactored topology initialisation and access in the Environment class.


Close #119 